### PR TITLE
PAY-1541: applied fix for dir, magento connect install.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -65,7 +65,11 @@
                     <dir name="default">
                         <dir name="layout">
                             <file hash="770b2da9a019e06ef950b0fc75f1ab23" name="razorpay.xml"/>
-                            <file hash="" name="checkout.phtml"/>
+                        </dir>
+                        <dir name="template">
+                            <dir name="razorpay">
+                                <file hash="" name="checkout.phtml"/>
+                            </dir>
                         </dir>
                     </dir>
                 </dir>
@@ -82,7 +86,7 @@
         <required>
             <php>
                 <min>5.4.45</min>
-                <max>5.6.26</max>
+                <max>7.2.3</max>
             </php>
         </required>
     </dependencies>


### PR DESCRIPTION
To install this package through magento connect, fixed the directory structure in package file. Magento connect requires ".tgz" extension to install it.  